### PR TITLE
Fix DATABASE_URL requirement for Render deployment

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -20,7 +20,7 @@ class Settings(BaseSettings):
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
     
     # Database
-    DATABASE_URL: str
+    DATABASE_URL: str = "sqlite:///./app.db"
     TEST_DATABASE_URL: Optional[str] = None
     
     # Redis


### PR DESCRIPTION
- Made DATABASE_URL optional with SQLite default
- Fixes deployment failure where DATABASE_URL was required but not provided