### PR TITLE
Optimize for Render.com memory constraints

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -12,6 +12,13 @@ When deploying to Render.com, you need to manually set these environment variabl
 #### Optional
 - `SENTRY_DSN` - For error tracking (optional)
 
+### Memory Optimization
+
+The app is optimized for Render's free tier (512MB memory limit):
+- Uses single worker process (`-w 1`) instead of multiple workers
+- Extended timeout (`--timeout 120`) to handle AI model loading
+- Preload application (`--preload`) to reduce memory overhead
+
 ### Deployment Steps
 
 1. **Fork this repository** to your GitHub account

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: gunicorn -w 4 -k uvicorn.workers.UvicornWorker app.main:app
+web: gunicorn -w 1 -k uvicorn.workers.UvicornWorker app.main:app --timeout 120 --preload --max-requests 1000 --max-requests-jitter 100
 worker: celery -A app.worker worker --loglevel=info

--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,7 @@ services:
     env: python
     plan: starter
     buildCommand: "./build.sh"
-    startCommand: "gunicorn -w 4 -k uvicorn.workers.UvicornWorker app.main:app --bind 0.0.0.0:$PORT"
+    startCommand: "gunicorn -w 1 -k uvicorn.workers.UvicornWorker app.main:app --bind 0.0.0.0:$PORT --timeout 120 --preload"
     envVars:
       - key: PYTHON_VERSION
         value: "3.11"


### PR DESCRIPTION
- Reduce workers from 4 to 1 to prevent memory issues
- Increase timeout to 120s for AI model loading
- Add preload flag to reduce memory overhead
- Update deployment documentation with memory optimization notes