### PR TITLE
Fix Dockerfile to use app.main instead of deleted minimal_main

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,4 @@ USER appuser
 EXPOSE 8000
 
 # Command to run the application - single worker for free tier
-CMD ["uvicorn", "minimal_main:app", "--host", "0.0.0.0", "--port", "8000", "--timeout-keep-alive", "120"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--timeout-keep-alive", "120"]


### PR DESCRIPTION
- Update CMD in Dockerfile to reference app.main:app
- Resolves deployment error 'Could not import module minimal_main'
- Ensures all deployment configurations use the correct main module