### PR TITLE
Fix Invalid host header issue by temporarily allowing all hosts

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -46,10 +46,10 @@ if settings.BACKEND_CORS_ORIGINS:
         allow_headers=["*"],
     )
 
-# Trusted host middleware
+# Trusted host middleware - Allow all hosts for now to debug
 app.add_middleware(
     TrustedHostMiddleware,
-    allowed_hosts=["*"] if settings.DEBUG else ["jonaspetersen.com", "*.render.com"]
+    allowed_hosts=["*"]
 )
 
 # Include API router


### PR DESCRIPTION
- Change TrustedHostMiddleware to allow all hosts to resolve 400 errors
- Fix CORS origins to only include frontend domains (removed onrender.com)
- This addresses the systematic 400 Bad Request errors from Render's health checks
- Will restore proper host validation once working